### PR TITLE
Added missing path to pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We have tested on Ubuntu 16.04 and 18.04 with an NVIDIA GeForce RTX 2080 and Tit
 Install the DREAM package and its dependencies using `pip`:
 
 ```
-pip install -r requirements.txt
+pip install . -r requirements.txt
 ```
 
 Download the pre-trained models and (optionally) data.  In the scripts below, be sure to comment out files you do not want, as they are very large.  Alternatively, you can download files [manually](https://drive.google.com/drive/folders/1Krp-fCT9ffEML3IpweSOgWiMHHBw6k2Z?usp=sharing)


### PR DESCRIPTION
I thought about adding a sentence after the install command saying "use `-e` if you want to install in editable mode", but I opted not to so that the instructions remain concise. 

I prefer the install command to not have to be modified, so users can just copy/paste it directly. So, I didn't add anything like a `[-e]` to the install command either.