### PR TITLE
Adding enum34 package to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 future
 albumentations
+enum34
 matplotlib
 numpy
 opencv-python


### PR DESCRIPTION
Adding `enum34` to `requirements.txt` to backport enumerations when running with Python 2.

Specifically, this fixes the following bug:
```
(dream-final-py2) telee@iam-ronan:~/ws/DREAM$ python scripts/launch_dream_ros.py -i trained_models/panda_dream_vgg_q.pth -b panda_link0 -v
Traceback (most recent call last):
  File "scripts/launch_dream_ros.py", line 25, in <module>
    import dream
  File "/home/telee/ws/DREAM/dream/__init__.py", line 4, in <module>
    from .datasets import *
  File "/home/telee/ws/DREAM/dream/datasets.py", line 5, in <module>
    from enum import IntEnum
ImportError: No module named enum
```