### PR TITLE
Develop

### DIFF
--- a/dream/__init__.py
+++ b/dream/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 from .analysis import *
 from .datasets import *

--- a/dream/network.py
+++ b/dream/network.py
@@ -553,7 +553,7 @@ class DreamNetwork:
                         if self.use_belief_peak_scores and len(peak) > 1:
                             # Try to use the belief map scores
                             peak_sorted_by_score = sorted(
-                                peak, key=lambda x: x[1], reverse=True
+                                peak, key=lambda x: x[2], reverse=True
                             )
                             if (
                                 peak_sorted_by_score[0][2] - peak_sorted_by_score[1][2]


### PR DESCRIPTION
This PR implements the bug fix for closing #21 and increments the version of DREAM to 1.2.0.

Issue #21 identified that the belief map score routine does not sort multiple belief map peaks as expected. The code introduced in this PR will properly sort by belief map score. This code has been tested through inference on the Panda3Cam dataset with the DREAM-vgg-Q network. Although the occurrence of this bug is uncommon (multiple belief map peaks were detected in only 3% of frames in the conducted test), this code does lead to strictly better performance improvements, such as in AUC (+0.001 for both 2D & 3D metrics) and percentage of frames where PnP was successful when viable (+0.5%).

Credit to @ThakurSarveshGit for finding this bug. Thank you!