### PR TITLE
fix(datasets): demo __main__ omits required constructor (+1 more)

### DIFF
--- a/dream/datasets.py
+++ b/dream/datasets.py
@@ -303,6 +303,8 @@ if __name__ == "__main__":
         keypoint_names,
         (400, 400),
         (100, 100),
+        None,
+        "resize",
         include_belief_maps=True,
         augment_data=True,
     )
@@ -310,7 +312,7 @@ if __name__ == "__main__":
         train_dataset, batch_size=32, shuffle=False, num_workers=1, pin_memory=True
     )
 
-    targets = iter(trainingdata).next()
+    targets = next(iter(trainingdata))
 
     for i, b in enumerate(targets["belief_maps"][0]):
         print(b.shape)


### PR DESCRIPTION
Small fixes in `dream/datasets.py`:

#### fix: demo __main__ omits required constructor arguments

**Fix:** Replace:
```
    train_dataset = ManipulatorNDDSDataset(
        found_data,
        "panda",
        keypoint_names,
        (400, 400),
        (100, 100),
        include_belief_maps=True,
        augment_data=True,
    )
```

with:
```
    train_dataset = ManipulatorNDDSDataset(
        found_data,
        "panda",
        keypoint_names,
        (400, 400),
        (100, 100),
        None,
        "resize",
        include_belief_maps=True,
        augment_data=True,
    )
```

#### fix: iter(...).next() is invalid Python 3 iterator syntax

**Fix:** Replace:
```
    targets = iter(trainingdata).next()
```

with:
```
    targets = next(iter(trainingdata))
```

### Files changed
- `dream/datasets.py`