### PR TITLE
fix(geometric-vision): convert_rvec_to_quaternion divides (+1 more)

### DIFF
--- a/dream/geometric_vision.py
+++ b/dream/geometric_vision.py
@@ -14,6 +14,13 @@ def convert_rvec_to_quaternion(rvec):
     theta = np.sqrt(
         rvec[0] * rvec[0] + rvec[1] * rvec[1] + rvec[2] * rvec[2]
     )  # in radians
+
+    # A zero-magnitude rotation vector is the identity rotation.
+    if theta < 1e-8:
+        quaternion = Quaternion([0.0, 0.0, 0.0, 1.0])
+        quaternion.normalize()
+        return quaternion
+
     raxis = [rvec[0] / theta, rvec[1] / theta, rvec[2] / theta]
 
     # pyrr's Quaternion (order is XYZW), https://pyrr.readthedocs.io/en/latest/oo_api_quaternion.html


### PR DESCRIPTION
Small fixes in `dream/geometric_vision.py`:

#### fix: convert_rvec_to_quaternion divides by zero for zero rotation

**Fix:** Replace:
```
    theta = np.sqrt(
        rvec[0] * rvec[0] + rvec[1] * rvec[1] + rvec[2] * rvec[2]
    )  # in radians
    raxis = [rvec[0] / theta, rvec[1] / theta, rvec[2] / theta]

    # pyrr's Quaternion (order is XYZW), https://pyrr.readthedocs.io/en/latest/oo_api_quaternion.html
    quaternion = Quaternion.from_axis_rotation(raxis, theta)
    quaternion.normalize()
    return quaternion
```

with:
```
    theta = np.sqrt(
        rvec[0] * rvec[0] + rvec[1] * rvec[1] + rvec[2] * rvec[2]
    )  # in radians

    # A zero-magnitude rotation vector is the identity rotation.
    if theta < 1e-8:
        quaternion = Quaternion([0.0, 0.0, 0.0, 1.0])
        quaternion.normalize()
        return quaternion

    raxis = [rvec[0] / theta, rvec[1] / theta, rvec[2] / theta]

    # pyrr's Quaternion (order is XYZW), https://pyrr.readthedocs.io/en/latest/oo_api_quaternion.html
    quaternion = Quaternion.from_axis_rotation(raxis, theta)
    quaternion.normalize()
    return quaternion
```

#### fix: add_from_pose transforms ground-truth points against themselves

**Fix:** Replace:
```
def add_from_pose(translation, quaternion, keypoint_positions_wrt_cam_gt, camera_K):
    transform = np.eye(4)
    transform[:3, :3] = quaternion.matrix33.tolist()
    transform[:3, -1] = translation
    kp_pos_gt_homog = np.hstack(
        (
            keypoint_positions_wrt_cam_gt,
            np.ones((keypoint_positions_wrt_cam_gt.shape[0], 1)),
        )
    )
    kp_pos_aligned = np.transpose(np.matmul(transform, np.transpose(kp_pos_gt_homog)))[
        :, :3
    ]
    # The below lines were useful when debugging pnp ransac, so left here for now
    # projs = point_projection_from_3d(camera_K, kp_pos_aligned)
    # temp = np.linalg.norm(kp_projs_est_pnp - projs, axis=1) # all of these should be below the inlier threshold above!
    kp_3d_errors = kp_pos_aligned - keypoint_positions_wrt_cam_gt
    kp_3d_l2_errors = np.linalg.norm(kp_3d_errors, axis=1)
    add = np.mean(kp_3d_l2_errors)
    return add
```

with:
```
def add_from_pose(translation, quaternion, keypoint_positions, keypoint_positions_wrt_cam_gt, camera_K):
    transform = np.eye(4)
    transform[:3, :3] = quaternion.matrix33.tolist()
    transform[:3, -1] = translation
    kp_pos_homog = np.hstack(
        (
            keypoint_positions,
            np.ones((keypoint_positions.shape[0], 1)),
        )
    )
    kp_pos_est_wrt_cam = np.transpose(np.matmul(transform, np.transpose(kp_pos_homog)))[
        :, :3
    ]
    # The below lines were useful when debugging pnp ransac, so left here for now
    # projs = point_projection_from_3d(camera_K, kp_pos_est_wrt_cam)
    # temp = np.linalg.norm(kp_projs_est_pnp - projs, axis=1) # all of these should be below the inlier threshold above!
    kp_3d_errors = kp_pos_est_wrt_cam - keypoint_positions_wrt_cam_gt
    kp_3d_l2_errors = np.linalg.norm(kp_3d_errors, axis=1)
    add = np.mean(kp_3d_l2_errors)
    return add
```

### Files changed
- `dream/geometric_vision.py`