### PR TITLE
fix: self.soft_argmax used but never instantiated

### DIFF
--- a/dream/network.py
+++ b/dream/network.py
@@ -297,6 +297,8 @@ class DreamNetwork:
                 self.architecture_type
             )
 
+        self.soft_argmax = SoftArgmaxPavlo(self.n_keypoints)
+
         # Optimizer is created in a separate call, because this isn't needed unless we're training
         self.optimizer = None
 


### PR DESCRIPTION
### Problem
fix: self.soft_argmax used but never instantiated

### Fix
Replace:
```
        # Optimizer is created in a separate call, because this isn't needed unless we're training
        self.optimizer = None
```

with:
```
        self.soft_argmax = SoftArgmaxPavlo(self.n_keypoints)

        # Optimizer is created in a separate call, because this isn't needed unless we're training
        self.optimizer = None
```

### Files changed
- `dream/network.py`