### PR TITLE
fix(launch-dream-ros): capture_frame service calls global (+1 more)

### DIFF
--- a/scripts/launch_dream_ros.py
+++ b/scripts/launch_dream_ros.py
@@ -178,12 +178,15 @@ class DreamInferenceROS:
 
     def on_capture_frame(self, req):
         print("Capturing frame.")
-        found_kp_projs_net_input = dream_ros.process_image()
+        found_kp_projs_net_input = self.process_image()
+        if found_kp_projs_net_input is None:
+            print("No image available yet -- not continuing.")
+            return []
         print(found_kp_projs_net_input)
         (
             kp_projs_raw_good_sample,
             kp_positions_good_sample,
-        ) = dream_ros.keypoint_correspondences(found_kp_projs_net_input)
+        ) = self.keypoint_correspondences(found_kp_projs_net_input)
         if self.capture_frame_max_kps and kp_projs_raw_good_sample is not None:
             n_found_keypoints = kp_projs_raw_good_sample.shape[0]
             if n_found_keypoints != self.dream_network.n_keypoints:
@@ -197,7 +200,7 @@ class DreamInferenceROS:
             kp_projs_raw_good_sample is not None
             and kp_positions_good_sample is not None
         ):
-            dream_ros.solve_pnp_buffer(
+            self.solve_pnp_buffer(
                 kp_projs_raw_good_sample, kp_positions_good_sample
             )
         return []


### PR DESCRIPTION
Small fixes in `scripts/launch_dream_ros.py`:

#### fix: capture_frame service calls global dream_ros instead of self

**Fix:** Replace:
```
    def on_capture_frame(self, req):
        print("Capturing frame.")
        found_kp_projs_net_input = dream_ros.process_image()
        print(found_kp_projs_net_input)
        (
            kp_projs_raw_good_sample,
            kp_positions_good_sample,
        ) = dream_ros.keypoint_correspondences(found_kp_projs_net_input)
        if self.capture_frame_max_kps and kp_projs_raw_good_sample is not None:
            n_found_keypoints = kp_projs_raw_good_sample.shape[0]
            if n_found_keypoints != self.dream_network.n_keypoints:
                print(
                    "Only found {} keypoints -- not continuing. Try again.".format(
                        n_found_keypoints
                    )
                )
                return []
        if (
            kp_projs_raw_good_sample is not None
            and kp_positions_good_sample is not None
        ):
            dream_ros.solve_pnp_buffer(
                kp_projs_raw_good_sample, kp_positions_good_sample
            )
        return []
```

with:
```
    def on_capture_frame(self, req):
        print("Capturing frame.")
        found_kp_projs_net_input = self.process_image()
        if found_kp_projs_net_input is None:
            print("No image available yet -- not continuing.")
            return []
        print(found_kp_projs_net_input)
        (
            kp_projs_raw_good_sample,
            kp_positions_good_sample,
        ) = self.keypoint_correspondences(found_kp_projs_net_input)
        if self.capture_frame_max_kps and kp_projs_raw_good_sample is not None:
            n_found_keypoints = kp_projs_raw_good_sample.shape[0]
            if n_found_keypoints != self.dream_network.n_keypoints:
                print(
                    "Only found {} keypoints -- not continuing. Try again.".format(
                        n_found_keypoints
                    )
                )
                return []
        if (
            kp_projs_raw_good_sample is not None
            and kp_positions_good_sample is not None
        ):
            self.solve_pnp_buffer(
                kp_projs_raw_good_sample, kp_positions_good_sample
            )
        return []
```

#### fix: truthiness rejects keypoints at image coordinate zero

**Fix:** Replace:
```
            if (
                this_kp_proj_est is not None
                and this_kp_proj_est[0]
                and this_kp_proj_est[1]
                and not (this_kp_proj_est[0] < -999.0 and this_kp_proj_est[1] < 0.999)
            ):
```

with:
```
            if (
                this_kp_proj_est is not None
                and not (this_kp_proj_est[0] < -999.0 and this_kp_proj_est[1] < 0.999)
            ):
```

### Files changed
- `scripts/launch_dream_ros.py`