### PR TITLE
fix(train-network): resuming training crashes with (+1 more)

### DIFF
--- a/scripts/train_network.py
+++ b/scripts/train_network.py
@@ -84,6 +84,11 @@ def train_network(args):
         epoch_numbers = [x[1] for x in temp]
 
         # Most recent network
+        assert len(epoch_weight_paths) > 0, (
+            "Could not find any epoch weights in {} to resume training.".format(
+                args.output_dir
+            )
+        )
         most_recent_epoch_weight_path = epoch_weight_paths[0]
         start_epoch = epoch_numbers[0]
 
@@ -459,7 +464,7 @@ def train_network(args):
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
     print("")
 
-    last_epoch_timestamp = 0.0
+    last_epoch_timestamp = training_start_time
 
     for e in tqdm(range(start_epoch, args.epochs)):
         this_epoch = e + 1
@@ -619,7 +624,7 @@ def train_network(args):
                     args.output_dir, "best_network", overwrite=True
                 )
 
-        this_epoch_timestamp = time.time() - training_start_time
+        this_epoch_timestamp = time.time()
         print(
             "This epoch took {} seconds.".format(
                 this_epoch_timestamp - last_epoch_timestamp
@@ -636,7 +641,7 @@ def train_network(args):
         train_log["batch_validation_losses"].append(valid_batch_losses)
         train_log["batch_training_sample_names"].append(training_batch_sample_names)
         train_log["batch_validation_sample_names"].append(valid_batch_sample_names)
-        train_log["timestamps"].append(this_epoch_timestamp)
+        train_log["timestamps"].append(this_epoch_timestamp - training_start_time)
 
         if save_results:
             # Write training log so far


### PR DESCRIPTION
Small fixes in `scripts/train_network.py`:

#### fix: resuming training crashes with IndexError when no epoch weights exist

**Fix:** Replace:
```
        epoch_weight_paths = [x[0] for x in temp]
        epoch_numbers = [x[1] for x in temp]

        # Most recent network
        most_recent_epoch_weight_path = epoch_weight_paths[0]
        start_epoch = epoch_numbers[0]
```

with:
```
        epoch_weight_paths = [x[0] for x in temp]
        epoch_numbers = [x[1] for x in temp]

        # Most recent network
        assert len(epoch_weight_paths) > 0, (
            "Could not find any epoch weights in {} to resume training.".format(
                args.output_dir
            )
        )
        most_recent_epoch_weight_path = epoch_weight_paths[0]
        start_epoch = epoch_numbers[0]
```

#### fix: first epoch duration printed as total elapsed time, not real duration

**Fix:** Apply patch:
```diff
--- a/scripts/train_network.py
+++ b/scripts/train_network.py
@@ -525,7 +525,7 @@
     print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
     print("")
 
-    last_epoch_timestamp = 0.0
+    last_epoch_timestamp = training_start_time
 
     for e in tqdm(range(start_epoch, args.epochs)):
         this_epoch = e + 1
@@ -620,7 +620,7 @@
         print("")
 
         # Append to history
-        this_epoch_timestamp = time.time() - training_start_time
+        this_epoch_timestamp = time.time()
         train_log["epochs"].append(this_epoch)
         train_log["losses"].append(mean_training_loss_per_batch)
         train_log["validation_losses"].append(mean_valid_loss_per_batch)
@@ -628,7 +628,7 @@
         train_log["batch_training_sample_names"].append(training_batch_sample_names)
         train_log["batch_validation_sample_names"].append(valid_batch_sample_names)
-        train_log["timestamps"].append(this_epoch_timestamp)
+        train_log["timestamps"].append(this_epoch_timestamp - training_start_time)
 
         if save_results:
             # Write training log so far
```

### Files changed
- `scripts/train_network.py`