### PR TITLE
fix: missing dream import causes NameError in train_network_multi

### DIFF
--- a/scripts/train_network_multi.py
+++ b/scripts/train_network_multi.py
@@ -6,6 +6,8 @@ import argparse
 import os
 import subprocess
 
+import dream
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Totally developmental script


### PR DESCRIPTION
### Problem
fix: missing dream import causes NameError in train_network_multi

### Fix
Replace:
```
import os
import subprocess
```

with:
```
import os
import subprocess

import dream
```

### Files changed
- `scripts/train_network_multi.py`