### PR TITLE
fix: only top-level dream package is installed, subpackages omitted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     maintainer='Timothy Lee',
     maintainer_email='timothyelee@cmu.edu',
     description='Deep Robot-to-camera Extrinsics for Articulated Manipulators',
-    packages=['dream'],
+    packages=find_packages(),
     package_dir={'dream': 'dream'},
     zip_safe=False
 )


### PR DESCRIPTION
### Problem
fix: only top-level dream package is installed, subpackages omitted

### Fix
Replace:
```
    packages=['dream'],
    package_dir={'dream': 'dream'},
```

with:
```
    packages=find_packages(),
    package_dir={'dream': 'dream'},
```

### Files changed
- `setup.py`