### PR TITLE
fix: move inference outputs to CPU before numpy/PIL use

### DIFF
--- a/scripts/visualize_network_inference.py
+++ b/scripts/visualize_network_inference.py
@@ -266,13 +266,13 @@ def visualize_network_inference(args):
                     if needs_belief_maps:
                         belief_maps = belief_maps_batch[b]
                         selected_belief_maps_copy = (
-                            belief_maps[idx_keypoints, :, :].detach().clone()
+                            belief_maps[idx_keypoints, :, :].detach().cpu().clone()
                         )
                     else:
                         selected_belief_maps_copy = []
 
                     detected_kp_projs_netout = np.array(
-                        detected_kp_projs_netout_batch[b], dtype=float
+                        detected_kp_projs_netout_batch[b].cpu(), dtype=float
                     )
                     selected_detected_kp_projs_netout = detected_kp_projs_netout[
                         idx_keypoints, :


### PR DESCRIPTION
### Problem
fix: move inference outputs to CPU before numpy/PIL use

### Fix
Apply patch:
```diff
--- a/scripts/visualize_network_inference.py
+++ b/scripts/visualize_network_inference.py
@@ -188,7 +188,7 @@ def visualize_network_inference(args):
                     if needs_belief_maps:
                         belief_maps = belief_maps_batch[b]
                         selected_belief_maps_copy = (
-                            belief_maps[idx_keypoints, :, :].detach().clone()
+                            belief_maps[idx_keypoints, :, :].detach().cpu().clone()
                         )
                     else:
                         selected_belief_maps_copy = []
@@ -197,7 +197,7 @@ def visualize_network_inference(args):
                     selected_belief_maps_copy = []
 
                     detected_kp_projs_netout = np.array(
-                        detected_kp_projs_netout_batch[b], dtype=float
+                        detected_kp_projs_netout_batch[b].cpu(), dtype=float
                     )
                     selected_detected_kp_projs_netout = detected_kp_projs_netout[
                         idx_keypoints, :
```

### Files changed
- `scripts/visualize_network_inference.py`